### PR TITLE
ENHANCE: 브라우저 비율에 구애받지 않고 픽셀 단위로 슬롯을 넘기고 보여주도록

### DIFF
--- a/swipe.js
+++ b/swipe.js
@@ -333,19 +333,15 @@
         if (this.p === this.total + 1) {
           this.p = 1;
           this.offset++;
-          // fixed coordinates after transition
-          this.$target.each(function (idx) {
-            var left = this_.getWidth(true) * (this_.offset + idx - 1);
-            $(this).css('left', left + 'px');
-          });
         } else if (this.p === 0) {
           this.p = this.total;
           this.offset--;
-          this.$target.each(function (idx) {
-            var left = this_.getWidth(true) * (this_.offset + idx - 1);
-            $(this).css('left', left + 'px');
-          });
         }
+        // fixed coordinates after transition
+        this.$target.each(function (idx) {
+          var left = this_.getWidth(true) * (this_.offset + idx - 1);
+          $(this).css('left', left + 'px');
+        });
       }
 
       this.curr_px = 0;

--- a/swipe.js
+++ b/swipe.js
@@ -132,10 +132,10 @@
       if (this.options.infinite) {
         var clone1 = this.$target.clone().attr('aria-hidden', true)
                .addClass('infinite-swipe-target-clone')
-               .css('left', '-' + this.options.total * 100 + '%');
+               .css('left', '-' + this.getWidth(true) + 'px');
         var clone2 = this.$target.clone().attr('aria-hidden', true)
                .addClass('infinite-swipe-target-clone')
-               .css('left', this.options.total * 100 + '%');
+               .css('left', this.getWidth(true) + 'px');
         clone1.insertBefore(this.$target);
         clone2.insertBefore(this.$target);
         this.$target = this.$target.parent().find('.infinite-swipe-target');
@@ -243,7 +243,7 @@
       this.offset = 0;
       this.animate();
       this.$target.each(function (idx) {
-        $(this).css('left', this_.total * (this_.offset + idx) * 100 + '%');
+        $(this).css('left', this_.getWidth(true) * (this_.offset + idx) + 'px');
       });
     },
     onSwipePage: function (e, new_page) {
@@ -335,15 +335,15 @@
           this.offset++;
           // fixed coordinates after transition
           this.$target.each(function (idx) {
-            var left = this_.total * (this_.offset + idx - 1) * 100;
-            $(this).css('left', left + '%');
+            var left = this_.getWidth(true) * (this_.offset + idx - 1);
+            $(this).css('left', left + 'px');
           });
         } else if (this.p === 0) {
           this.p = this.total;
           this.offset--;
           this.$target.each(function (idx) {
-            var left = this_.total * (this_.offset + idx - 1) * 100;
-            $(this).css('left', left + '%');
+            var left = this_.getWidth(true) * (this_.offset + idx - 1);
+            $(this).css('left', left + 'px');
           });
         }
       }


### PR DESCRIPTION
비율 단위로 css를 설정할 경우 디바이스나 브라우저 확대 배율에 따라 배율로 설정한 크기와 pixel 단위로 설정한 크기가 불일치하는 경우가 발생한다.
translate3D로 현재 보여줄 위치를 지정하는 부분이 px 단위였고, left로 element들의 배치를 지정하는 부분이 %단위라 보여질 때 어긋나서 보여지는 예시가 발생했다.

https://www.notion.so/dableglobal/iMBC-e046d476eab94a6f83d42b5fe3dfc4da